### PR TITLE
Replaced fixed percantage width instruction box with variable width

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ may seem scary, not fun. RailCode introduces programming
 in a game-like format, allowing people to program without 
 even realising that they are programming!
 
-[Visit RailCode.tk](http://railcode.tk) to find out more...
+[Visit RailCode.tk](http://web.archive.org/web/20160320212018/http://railcode.tk/ui/home.php) to find out more...
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
-#RailCode
+# RailCode
 Learn Computational Thinking using the London Underground
 
-RailCode teaches Computational Thinking (i.e: the basics of programming without being restricted to a particular programming language) in a rather unique way: the London Underground.
+RailCode teaches Computational Thinking (i.e: the basics 
+of programming without being restricted to a particular 
+programming language) in a rather unique way: the London 
+Underground.
 
-The rationale for this is simple. Programming is fun. But to someone who has never programmed before, programming may seem scary, not fun. RailCode introduces programming in a game-like format, allowing people to program without even realising that they are programming!
+The rationale for this is simple. Programming is fun. But 
+to someone who has never programmed before, programming 
+may seem scary, not fun. RailCode introduces programming 
+in a game-like format, allowing people to program without 
+even realising that they are programming!
 
 [Visit RailCode.tk](http://railcode.tk) to find out more...
 
 
-##Contributing
+## Contributing
 
-Suggestions, ideas and comment are always welcome. If you find a bug, please let us know.
+Suggestions, ideas and comment are always welcome. If you 
+find a bug, please let us know.

--- a/ui/main.php
+++ b/ui/main.php
@@ -33,9 +33,9 @@
 				text-align: center;
 			}
 			#trainInfoPanel {
-				height: 15%;
+				/* height: 15%; */
 				background-color: #F3F781;
-				overflow-y: scroll;
+				/* overflow-y: scroll; */
 				padding-top: 5px;
 				padding-bottom: 5px;
 				padding-left: 10px;


### PR DESCRIPTION
I don't know why we didn't do this in the first place. Having the description (i.e: Take the train from X to Y) box being a fixed 15% width and using a vertical scrollbar seems silly to me now.

Changed so that the div resizes itself to the width of the text that it contains.
